### PR TITLE
Fixed sort

### DIFF
--- a/client/dist/js/hasoneautocompletefield.js
+++ b/client/dist/js/hasoneautocompletefield.js
@@ -45,7 +45,7 @@
                                     var output = {
                                         label: item.name, // what's shown in the dropdown
                                         value: '',  // what's shown in the text field
-                                        id: id     // what's saved to the real field
+                                        id: item.id     // what's saved to the real field
                                     };
 
                                     if (item.currentString) {

--- a/src/forms/HasOneAutocompleteField.php
+++ b/src/forms/HasOneAutocompleteField.php
@@ -144,14 +144,16 @@ class HasOneAutocompleteField extends FormField
      */
     protected function processResults($results)
     {
-        $json = array();
+        $json = [];
+        $count = 0;
         foreach($results as $result) {
             $name = $result->{$this->labelField};
-
-            $json[$result->ID] = array(
+            
+            $json[$count++] = [
+                'id' => $result->ID,
                 'name' => $name,
                 'currentString' => $this->getCurrentItemText($result)
-            );
+            ];
         }
 
         return $json;


### PR DESCRIPTION
Item sort from PHP is overriden because array/script uses ID as array index.
Records are not sorted correctly as they should be after JS parse.

Object IDs are now passed as parameter.