### PR TITLE
Added clear button

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,0 +1,6 @@
+---
+name: hasoneautocompletefield
+---
+
+NathanCox\HasOneAutocompleteField\Forms\HasOneAutocompleteField:
+  clearButtonEnabled: false

--- a/client/dist/css/hasoneautocompletefield.css
+++ b/client/dist/css/hasoneautocompletefield.css
@@ -25,7 +25,8 @@
     display: inline-block;
 }
 .hasoneautocomplete.showsearch .hasoneautocomplete-currenttext,
-.hasoneautocomplete.showsearch .hasoneautocomplete-editbutton {
+.hasoneautocomplete.showsearch .hasoneautocomplete-editbutton,
+.hasoneautocomplete.showsearch .hasoneautocomplete-clearbutton {
     display: none;
 }
 

--- a/client/dist/js/hasoneautocompletefield.js
+++ b/client/dist/js/hasoneautocompletefield.js
@@ -17,6 +17,38 @@
             }
         });
 
+        $(".hasoneautocomplete-clearbutton").entwine({
+            onclick: function() {
+                var defaultText = String(this.closest('.hasoneautocomplete').data('default-text')).trim();
+                var $currentText = this.closest('.hasoneautocomplete').find('.hasoneautocomplete-currenttext').first();
+                var $idField = this.closest('.hasoneautocomplete').find('.hasoneautocomplete-id').first();
+                if ($currentText.length && $idField.length) {
+                    if (defaultText === '') {
+                        defaultText = '(none)';
+                    }
+
+                    $currentText.html(defaultText);
+                    $idField.val(0).change();
+                }
+			},
+			onmatch: function() {
+                $idField = this.closest('.hasoneautocomplete').find('.hasoneautocomplete-id').first();
+                if ($idField.length) {
+                    $idField.change(function(event) {
+                        var $clearButton = $(this).closest('.hasoneautocomplete').find('.hasoneautocomplete-clearbutton').first();
+                        if ($clearButton.length) {
+                            var newValue = String($(this).val()).trim();
+                            if (newValue === '' || newValue === '0') {
+                                $clearButton.hide();
+                            } else {
+                                $clearButton.show();
+                            }
+                        }
+                    });
+                }
+			}
+		});
+
         $(".hasoneautocomplete-search").entwine({
             onmatch: function (event) {
                 var t = this;

--- a/src/forms/HasOneAutocompleteField.php
+++ b/src/forms/HasOneAutocompleteField.php
@@ -12,6 +12,7 @@ use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\FormAction;
 use SilverStripe\Forms\TextField;
 use SilverStripe\Forms\HiddenField;
+use SilverStripe\Core\Config\Config;
 
 class HasOneAutocompleteField extends FormField
 {
@@ -61,6 +62,8 @@ class HasOneAutocompleteField extends FormField
      */
     protected $searchFields = false;
 
+    protected $clearButtonEnabled = false;
+
     /**
      * @param string $name         The field name
      * @param string $title        The label text
@@ -71,6 +74,8 @@ class HasOneAutocompleteField extends FormField
     {
         $this->sourceObject = $sourceObject;
         $this->labelField   = $labelField;
+
+        $this->clearButtonEnabled = Config::inst()->get(HasOneAutocompleteField::class, 'clearButtonEnabled');
 
         parent::__construct($name, $title);
     }
@@ -260,6 +265,28 @@ class HasOneAutocompleteField extends FormField
         return $this;
     }
 
+    public function enableClearButton()
+    {
+        $this->setClearButtonEnabled(true);
+        return $this;
+    }
+
+    public function disableClearButton()
+    {
+        $this->setClearButtonEnabled(false);
+        return $this;
+    }
+
+    private function getClearButtonEnabled()
+    {
+        return $this->clearButtonEnabled;
+    }
+
+    private function setClearButtonEnabled(bool $enabled = true)
+    {
+        $this->clearButtonEnabled = $enabled;
+        return $this;
+    }
 
     public function Field($properties = array())
     {
@@ -293,6 +320,17 @@ class HasOneAutocompleteField extends FormField
         $cancelField->setUseButtonTag(true);
         $cancelField->setButtonContent('Cancel');
         $cancelField->addExtraClass('edit hasoneautocomplete-cancelbutton btn-outline-secondary');
+
+        if ($this->getClearButtonEnabled() === true) {
+            $fields->push($clearField = FormAction::create($this->name.'Clear', ''));
+            $clearField->setUseButtonTag(true);
+            $clearField->setButtonContent('Clear');
+            $clearField->addExtraClass('clear hasoneautocomplete-clearbutton btn-outline-danger btn-hide-outline action--delete btn-sm');
+
+            if (intval($this->value) === 0) {
+                $clearField->setAttribute('style', 'display:none;');
+            }
+        }
 
         return $fields;
     }

--- a/templates/NathanCox/HasOneAutocompleteField/Forms/HasOneAutocompleteField_holder.ss
+++ b/templates/NathanCox/HasOneAutocompleteField/Forms/HasOneAutocompleteField_holder.ss
@@ -1,4 +1,4 @@
-<div id="$HolderID" class="form-group field<% if $extraClass %> $extraClass<% end_if %>">
+<div id="$HolderID" class="form-group field<% if $extraClass %> $extraClass<% end_if %>" data-default-text="$defaultText">
     <% if $Title %>
         <label for="$ID" id="title-$ID" class="form__field-label">$Title</label>
     <% end_if %>


### PR DESCRIPTION
With the addition of the clear button you can now clear the hasoneautocompletefield selection, if you don't want to have a value present which was not possible until now.

By default the clear button is disabled and you can enable it via .yml or directly on the field itself.