### PR TITLE
Tweak Readonly and Disabled fallback content

### DIFF
--- a/src/forms/HasOneAutocompleteField.php
+++ b/src/forms/HasOneAutocompleteField.php
@@ -297,6 +297,32 @@ class HasOneAutocompleteField extends FormField
     }
 
     /**
+     * Set read only state to use more user friendly value
+     *
+     * @return HasOneAutocompleteField_Readonly
+     */
+    public function performReadonlyTransformation()
+    {
+        $clone = parent::performReadonlyTransformation();
+        $clone->setValue($this->getCurrentItemText());
+
+        return $clone;
+    }
+
+    /**
+     * Set disabled state to use more user friendly value
+     *
+     * @return HasOneAutocompleteField_Readonly
+     */
+    public function performDisabledTransformation()
+    {
+        $clone = parent::performDisabledTransformation();
+        $clone->setValue($this->getCurrentItemText());
+
+        return $clone;
+    }
+
+    /**
      * Get the currently selected object
      * @return DataObject
      */


### PR DESCRIPTION
By default, the readonly/disabled fallback field displays the record ID, which can be a little odd.

This change makes the readonly/disabled field more consistent with the standard HasOneAutocompleteField, only without the ability to a record.